### PR TITLE
Add betterF to motions like delete, change, yank and to visual mode

### DIFF
--- a/lua/betterf.lua
+++ b/lua/betterf.lua
@@ -133,7 +133,9 @@ function M.setup(opts)
 
     -- keymaps
     vim.api.nvim_set_keymap('n', conf.mappings[1], [[:lua require'betterf'.betterF(true)<CR>]], { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', 'd'..conf.mappings[1], [[:lua require'betterf'.betterF(true,'d')<CR>]], { noremap = true, silent = true })
     vim.api.nvim_set_keymap('n', conf.mappings[2], [[:lua require'betterf'.betterF(false)<CR>]], { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('n', 'd'..conf.mappings[2], [[:lua require'betterf'.betterF(false,'d')<CR>]], { noremap = true, silent = true })
 end
 
 return M

--- a/lua/betterf.lua
+++ b/lua/betterf.lua
@@ -70,7 +70,7 @@ local function findInstancesAndReplace(buf_num, ns_id, match_char, is_forward)
     return char_match_idx
 end
 
-local function betterF(is_forward)
+local function betterF(is_forward, motion_command)
     local match_value = vim.fn.getchar()
     if match_value == 27 then
         return
@@ -98,11 +98,21 @@ local function betterF(is_forward)
         -- if it's not escape and the character exists in the matches, jump to the location
         if jump_value ~= 27 and index_char_match[jump_char] then
             local jump_location = index_char_match[jump_char]
-            vim.api.nvim_win_set_cursor(0, {jump_location[1], jump_location[2]-1})
+            local start_pos = vim.api.nvim_win_get_cursor(0)
+            local start_row = start_pos[1] - 1
+            local start_col = start_pos[2]
+            local end_row = jump_location[1] - 1
+            local end_col = jump_location[2]
 
-            -- if it's the last character, exit, otherwise we need to repeat the loop
-            if jump_char == conf.labels[#conf.labels] then
-                complete = false
+            if motion_command == 'd' then
+                vim.api.nvim_buf_set_text(buf_num, start_row, start_col, end_row, end_col, {})
+            else
+                vim.api.nvim_win_set_cursor(0, {jump_location[1], jump_location[2]-1})
+
+                -- if it's the last character, exit, otherwise we need to repeat the loop
+                if jump_char == conf.labels[#conf.labels] then
+                    complete = false
+                end
             end
         end
 


### PR DESCRIPTION
Hi, I made some changes to the plugin so that it also works for other motions and also in visual mode.
I really like this plugin and I think this would be a nice addtion.

I was initially working off the fork from @sumanthrao1997 but ultemately undid their changes because I found out that `nvim_win_set_cursor` would work with these motions in the O-Pending mode. So I only changed how the searching for the next characters with `;` works. Before it directly set the cursor to the first `;` char, which messed whith the motions. Now the cursor keeps in the initial place, but still searches from the first `;` on.